### PR TITLE
Update for compatibility with yazi 25.5.31

### DIFF
--- a/yazi.tera
+++ b/yazi.tera
@@ -21,14 +21,14 @@ bg = "#{{surface0.hex}}"
 fg = "#{{color.hex}}"
 {%- endmacro modehl -%}
 
-[completion.active]
+[cmp.active]
 bg = "#{{surface0.hex}}"
 fg = "#{{pink.hex}}"
 
-[completion.border]
+[cmp.border]
 fg = "#{{accent.hex}}"
 
-[completion.inactive]
+[cmp.inactive]
 fg = "#{{text.hex}}"
 
 {{self::ftrule(mime="image/*", color=aqua)}}
@@ -134,34 +134,39 @@ bg = "#{{subtext1.hex}}"
 fg = "#{{surface1.hex}}"
 
 {{self::modehl(name="normal", color=accent)}}
-{{self::modehl(name="select", color=pink)}}
+{{self::modehl(name="pick", color=pink)}}
 {{self::modehl(name="unset", color=subtext0)}}
 
-[select.active]
+[pick.active]
 fg = "#{{pink.hex}}"
 
-[select.border]
+[pick.border]
 fg = "#{{accent.hex}}"
 
-[select.inactive]
+[pick.inactive]
 fg = "#{{text.hex}}"
 
-[status]
-separator_close = ""
-separator_open = ""
-[status.permissions_r]
+[status.sep_left]
+open = ""
+close = ""
+
+[status.sep_right]
+open = ""
+close = ""
+
+[status.perm_read]
 fg = "#{{yellow.hex}}"
 
-[status.permissions_s]
+[status.perm_sep]
 fg = "#{{aqua.hex}}"
 
-[status.permissions_t]
+[status.perm_type]
 fg = "#{{blue.hex}}"
 
-[status.permissions_w]
+[status.perm_write]
 fg = "#{{purple.hex}}"
 
-[status.permissions_x]
+[status.perm_exec]
 fg = "#{{green.hex}}"
 
 [status.progress_error]


### PR DESCRIPTION
Thanks for the nice theme + variants! This PR updates them to be compatible with the latest version of yazi.

## Changes
It looks like there have been a number of breaking changes to yazi's theme format in [25.2.26](https://github.com/sxyazi/yazi/releases/tag/v25.2.26) and [25.5.31](https://github.com/sxyazi/yazi/releases/tag/v25.5.31), including:
* `completion` -> `cmp`
* `select` -> `pick`
* `status.permissions_r` -> `status.perm_read`, `w` -> `write`, `x` -> `exec`, `s` -> `sep`, `t` -> `type`
* Split separator into `status.sep_left` and `status.sep_right`


## Script
For others' reference, here's a simple python script that applies these changes to other theme files:

<details>
<summary>update_themes.py</summary>

```py
#!/usr/bin/env python3
"""Update yazi theme files from <=0.4 for compatibility with 25.5.31"""

import re
from pathlib import Path

STATUS_SEP_SECTIONS = """
[status.sep_left]
open = "{open_val}"
close = "{close_val}"

[status.sep_right]
open = "{open_val}"
close = "{close_val}"

""".lstrip()


def update_theme_file(file_path: Path):
    content = file_path.read_text()

    # Basic section renames
    content = re.sub(r'\[completion\.', '[cmp.', content)
    content = re.sub(r'\[\[mode\.([^\]]+)\]\]', r'[mode.\1]', content)
    content = re.sub(r'\[select\.', '[pick.', content)

    # Update status separator
    status_pattern = r'\[status\]\nseparator_close = "([^"]*)"\nseparator_open = "([^"]*)"\n'
    status_match = re.search(status_pattern, content)
    if status_match:
        close_val = status_match.group(1)
        open_val = status_match.group(2)
        replacement = STATUS_SEP_SECTIONS.format(close_val=close_val, open_val=open_val)
        content = re.sub(status_pattern, replacement, content)

    # Update permissions sections
    content = re.sub(r'\[status\.permissions_r\]', '[status.perm_read]', content)
    content = re.sub(r'\[status\.permissions_w\]', '[status.perm_write]', content)
    content = re.sub(r'\[status\.permissions_x\]', '[status.perm_exec]', content)
    content = re.sub(r'\[status\.permissions_s\]', '[status.perm_sep]', content)
    content = re.sub(r'\[status\.permissions_t\]', '[status.perm_type]', content)

    file_path.write_text(content)


for theme_file in Path('themes').glob('*.toml'):
    update_theme_file(theme_file)
```
</details>